### PR TITLE
feat: webhook support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-      - name: Run type checker
-        run: uv run --all-groups pyright
+      - name: Run type checker (core)
+        run: uv run --all-groups pyright src tests
+      - name: Run type checker (examples)
+        run: uv run --all-groups --extra examples pyright examples
 
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,9 +38,17 @@ repos:
       - id: pyright
         name: Pyright
         entry: uv run --all-groups pyright
+        args: [src, tests]
         language: system
-        types: [python]
-        pass_filenames: true
+        files: ^(src/|tests/).*\.py$
+        pass_filenames: false
+      - id: pyright-examples
+        name: Pyright (examples)
+        entry: uv run --all-groups --extra examples pyright
+        args: [examples]
+        language: system
+        files: ^examples/.*\.py$
+        pass_filenames: false
       - id: uv-lock-check
         name: Check uv.lock is up to date
         entry: uv lock --check

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ The following hooks run automatically on each commit:
 | `prettier` | Formats YAML and JSON files |
 | `ruff-format` | Formats Python code |
 | `ruff` | Lints Python code with auto-fix |
-| `pyright` | Type checking |
+| `pyright` | Type checking for `src/` and `tests/` |
+| `pyright-examples` | Type checking for `examples/` (requires `[examples]` extra) |
 | `uv-lock-check` | Ensures `uv.lock` is in sync with `pyproject.toml` |
 
 To run all hooks manually:

--- a/examples/webhook_handler.py
+++ b/examples/webhook_handler.py
@@ -37,7 +37,8 @@ try:
 except ImportError:
     _ngrok = None
 
-from bria_client import BriaAsyncClient, verify_webhook_signature
+from bria_client import BriaAsyncClient
+from bria_client.toolkit import verify_webhook_signature
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -123,7 +124,7 @@ async def main():
 
     if not public_url and _ngrok is not None:
         try:
-            tunnel = _ngrok.connect(8080)
+            tunnel = _ngrok.connect("8080")
             public_url = tunnel.public_url
             logger.info("ngrok tunnel opened: %s", public_url)
         except Exception as e:

--- a/examples/webhook_handler.py
+++ b/examples/webhook_handler.py
@@ -1,0 +1,133 @@
+"""
+Bria Webhook Handler Example
+=============================
+Demonstrates how to:
+  1. Submit an async job with a webhook_url so Bria POSTs results on completion.
+  2. Receive and verify the signed Bria webhook in a FastAPI endpoint.
+  3. (Optional) Use pyngrok to expose localhost for local development.
+
+Requirements:
+    pip install fastapi uvicorn bria-client
+    pip install pyngrok          # only needed for local dev tunnel
+
+Usage (local dev):
+    python examples/webhook_handler.py
+
+    The script starts a FastAPI server on port 8080, opens an ngrok tunnel,
+    submits a job with the tunnel URL as the webhook, then waits.
+    When Bria finishes the job it will POST to your local server.
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+import uvicorn
+from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
+
+try:
+    from pyngrok import ngrok as _ngrok
+except ImportError:
+    _ngrok = None
+
+from bria_client import BriaAsyncClient, verify_webhook_signature
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI()
+
+
+# ---------------------------------------------------------------------------
+# Webhook receiver endpoint
+# ---------------------------------------------------------------------------
+
+@app.post("/webhook")
+async def receive_webhook(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    bria_webhook_id: str = Header(...),
+    bria_webhook_timestamp: str = Header(...),
+    bria_webhook_signature: str = Header(...),
+):
+    """
+    Receive a Bria webhook delivery.
+
+    Bria signs every request with HMAC-SHA256. Always verify before processing.
+    Respond with 2xx within 10 seconds; defer heavy work to a background task.
+    """
+    api_token = os.environ["BRIA_API_TOKEN"]
+    body = await request.body()
+
+    if not verify_webhook_signature(
+        payload=body,
+        webhook_id=bria_webhook_id,
+        timestamp=bria_webhook_timestamp,
+        signature_header=bria_webhook_signature,
+        api_token=api_token,
+    ):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    data = json.loads(body)
+    logger.info("Webhook received", extra={"request_id": data.get("request_id"), "status": data.get("status")})
+
+    # Defer any slow processing so the 2xx response is sent within 10s
+    background_tasks.add_task(process_result, data)
+
+    return {"ok": True}
+
+
+async def process_result(data: dict):
+    """Handle the completed job result."""
+    logger.info("Processing result for request_id=%s status=%s", data.get("request_id"), data.get("status"))
+    # Your processing logic here
+
+
+# ---------------------------------------------------------------------------
+# Submit a job with a webhook_url
+# ---------------------------------------------------------------------------
+
+async def submit_with_webhook(webhook_url: str):
+    await asyncio.sleep(1)  # wait for uvicorn to finish starting
+    async with BriaAsyncClient() as client:
+        response = await client.submit(
+            endpoint="image/edit/remove_background",
+            payload={
+                "image": "https://bria-test-images.s3.us-east-1.amazonaws.com/sun-example.png",
+            },
+            webhook_url=webhook_url,
+        )
+        logger.info("Job submitted, request_id=%s — waiting for webhook delivery", response.request_id)
+
+
+# ---------------------------------------------------------------------------
+# Local dev entrypoint: starts ngrok tunnel + uvicorn + submits a job
+# ---------------------------------------------------------------------------
+
+async def main():
+    if _ngrok is not None:
+        tunnel = _ngrok.connect(8080)
+        public_url = tunnel.public_url
+        logger.info("ngrok tunnel: %s", public_url)
+    else:
+        public_url = os.environ.get("WEBHOOK_URL")
+        if not public_url:
+            raise RuntimeError(
+                "pyngrok is not installed and WEBHOOK_URL is not set. "
+                "Either `pip install pyngrok` or set WEBHOOK_URL to a publicly reachable URL."
+            )
+        logger.info("Using WEBHOOK_URL: %s", public_url)
+
+    webhook_url = f"{public_url}/webhook"
+
+    config = uvicorn.Config(app, host="0.0.0.0", port=8080, log_level="info")
+    server = uvicorn.Server(config)
+    await asyncio.gather(
+        server.serve(),
+        submit_with_webhook(webhook_url),
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/webhook_handler.py
+++ b/examples/webhook_handler.py
@@ -27,7 +27,7 @@ import uvicorn
 from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
 
 try:
-    from pyngrok import ngrok as _ngrok
+    from pyngrok import ngrok as _ngrok  # type: ignore[import-untyped]
 except ImportError:
     _ngrok = None
 
@@ -42,6 +42,7 @@ app = FastAPI()
 # ---------------------------------------------------------------------------
 # Webhook receiver endpoint
 # ---------------------------------------------------------------------------
+
 
 @app.post("/webhook")
 async def receive_webhook(
@@ -88,6 +89,7 @@ async def process_result(data: dict):
 # Submit a job with a webhook_url
 # ---------------------------------------------------------------------------
 
+
 async def submit_with_webhook(webhook_url: str):
     await asyncio.sleep(1)  # wait for uvicorn to finish starting
     async with BriaAsyncClient() as client:
@@ -105,6 +107,7 @@ async def submit_with_webhook(webhook_url: str):
 # Local dev entrypoint: starts ngrok tunnel + uvicorn + submits a job
 # ---------------------------------------------------------------------------
 
+
 async def main():
     if _ngrok is not None:
         tunnel = _ngrok.connect(8080)
@@ -114,8 +117,7 @@ async def main():
         public_url = os.environ.get("WEBHOOK_URL")
         if not public_url:
             raise RuntimeError(
-                "pyngrok is not installed and WEBHOOK_URL is not set. "
-                "Either `pip install pyngrok` or set WEBHOOK_URL to a publicly reachable URL."
+                "pyngrok is not installed and WEBHOOK_URL is not set. Either `pip install pyngrok` or set WEBHOOK_URL to a publicly reachable URL."
             )
         logger.info("Using WEBHOOK_URL: %s", public_url)
 

--- a/examples/webhook_handler.py
+++ b/examples/webhook_handler.py
@@ -7,21 +7,27 @@ Demonstrates how to:
   3. (Optional) Use pyngrok to expose localhost for local development.
 
 Requirements:
-    pip install fastapi uvicorn bria-client
-    pip install pyngrok          # only needed for local dev tunnel
+    uv run --extra examples python examples/webhook_handler.py
 
-Usage (local dev):
-    python examples/webhook_handler.py
+Local dev with ngrok tunnel:
+  ngrok requires a free account and auth token:
+    1. Sign up at https://dashboard.ngrok.com/signup (free)
+    2. Copy your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+    3. Run: ngrok config add-authtoken <your-token>
+  Then run this script — it will open a tunnel automatically.
 
-    The script starts a FastAPI server on port 8080, opens an ngrok tunnel,
-    submits a job with the tunnel URL as the webhook, then waits.
-    When Bria finishes the job it will POST to your local server.
+  Alternatively, set WEBHOOK_URL to any publicly reachable URL and skip ngrok:
+    WEBHOOK_URL=https://your-server.example.com/webhook uv run --extra examples python examples/webhook_handler.py
 """
 
 import asyncio
 import json
 import logging
 import os
+
+from dotenv import load_dotenv
+
+load_dotenv()  # picks up BRIA_API_TOKEN and WEBHOOK_URL from a .env file if present
 
 import uvicorn
 from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
@@ -37,6 +43,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+_shutdown_event = asyncio.Event()
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +91,9 @@ async def process_result(data: dict):
     logger.info("Processing result for request_id=%s status=%s", data.get("request_id"), data.get("status"))
     # Your processing logic here
 
+    # Shutdown the server
+    _shutdown_event.set()
+
 
 # ---------------------------------------------------------------------------
 # Submit a job with a webhook_url
@@ -109,25 +119,37 @@ async def submit_with_webhook(webhook_url: str):
 
 
 async def main():
-    if _ngrok is not None:
-        tunnel = _ngrok.connect(8080)
-        public_url = tunnel.public_url
-        logger.info("ngrok tunnel: %s", public_url)
-    else:
-        public_url = os.environ.get("WEBHOOK_URL")
-        if not public_url:
-            raise RuntimeError(
-                "pyngrok is not installed and WEBHOOK_URL is not set. Either `pip install pyngrok` or set WEBHOOK_URL to a publicly reachable URL."
+    public_url = os.environ.get("WEBHOOK_URL")
+
+    if not public_url and _ngrok is not None:
+        try:
+            tunnel = _ngrok.connect(8080)
+            public_url = tunnel.public_url
+            logger.info("ngrok tunnel opened: %s", public_url)
+        except Exception as e:
+            logger.warning(
+                "ngrok tunnel failed (%s). "
+                "Run 'ngrok config add-authtoken <token>' (free at https://dashboard.ngrok.com) "
+                "or set WEBHOOK_URL to a publicly reachable URL.",
+                e,
             )
-        logger.info("Using WEBHOOK_URL: %s", public_url)
+
+    if not public_url:
+        raise RuntimeError("No public URL available. Either configure an ngrok authtoken (ngrok config add-authtoken <token>) or set WEBHOOK_URL.")
 
     webhook_url = f"{public_url}/webhook"
 
     config = uvicorn.Config(app, host="0.0.0.0", port=8080, log_level="info")
     server = uvicorn.Server(config)
+
+    async def shutdown_when_done():
+        await _shutdown_event.wait()
+        server.should_exit = True
+
     await asyncio.gather(
         server.serve(),
         submit_with_webhook(webhook_url),
+        shutdown_when_done(),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ ignore = ["PERF203", "E402", "F821"]
 [dependency-groups]
 dev = [
     "pre-commit>=4.3.0",
-    "pyright>=1.1.407",
+    "pyright[nodejs]>=1.1.407",
     "ruff>=0.14.0",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ Documentation = "https://docs.bria.ai"
 Repository = "https://github.com/Bria-AI/bria-client"
 Issues = "https://github.com/Bria-AI/bria-client/issues"
 
+[project.optional-dependencies]
+examples = [
+    "fastapi>=0.136.1",
+    "pyngrok>=8.1.2",
+    "uvicorn>=0.47.0",
+]
+
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.0"
 

--- a/src/bria_client/__init__.py
+++ b/src/bria_client/__init__.py
@@ -1,5 +1,5 @@
 from bria_client._version import __version__
 from bria_client.clients import BriaAsyncClient, BriaSyncClient
-from bria_client.toolkit.webhook_verification import verify_webhook_signature
+from bria_client.toolkit import verify_webhook_signature
 
 __all__ = ["BriaSyncClient", "BriaAsyncClient", "__version__", "verify_webhook_signature"]

--- a/src/bria_client/__init__.py
+++ b/src/bria_client/__init__.py
@@ -1,4 +1,5 @@
 from bria_client._version import __version__
 from bria_client.clients import BriaAsyncClient, BriaSyncClient
+from bria_client.toolkit.webhook_verification import verify_webhook_signature
 
-__all__ = ["BriaSyncClient", "BriaAsyncClient", "__version__"]
+__all__ = ["BriaSyncClient", "BriaAsyncClient", "__version__", "verify_webhook_signature"]

--- a/src/bria_client/__init__.py
+++ b/src/bria_client/__init__.py
@@ -1,5 +1,4 @@
 from bria_client._version import __version__
 from bria_client.clients import BriaAsyncClient, BriaSyncClient
-from bria_client.toolkit import verify_webhook_signature
 
-__all__ = ["BriaSyncClient", "BriaAsyncClient", "__version__", "verify_webhook_signature"]
+__all__ = ["BriaSyncClient", "BriaAsyncClient", "__version__"]

--- a/src/bria_client/clients/async_client.py
+++ b/src/bria_client/clients/async_client.py
@@ -71,7 +71,9 @@ class BriaAsyncClient(BaseBriaClient):
             BriaResponse: The API response with request_id for polling
         """
         self._validate_submit_payload(payload)
-        merged_payload = {**payload, "sync": False, "webhook_url": webhook_url}
+        merged_payload = {**payload, "sync": False}
+        if webhook_url is not None:
+            merged_payload["webhook_url"] = webhook_url
         bria_response = await self.engine.post_async(endpoint=endpoint, payload=merged_payload, headers={**(headers or {})}, **kwargs)
         if raise_for_status:
             bria_response.raise_for_status()

--- a/src/bria_client/clients/async_client.py
+++ b/src/bria_client/clients/async_client.py
@@ -53,7 +53,7 @@ class BriaAsyncClient(BaseBriaClient):
             bria_response.raise_for_status()
         return bria_response
 
-    async def submit(self, endpoint: str, payload: dict, headers: dict | None = None, raise_for_status: bool = False, **kwargs):
+    async def submit(self, endpoint: str, payload: dict, headers: dict | None = None, raise_for_status: bool = False, webhook_url: str | None = None, **kwargs):
         """
         Submit an asynchronous request (sync=False)
 
@@ -62,14 +62,19 @@ class BriaAsyncClient(BaseBriaClient):
             payload: Request payload
             headers: Optional headers
             raise_for_status: Whether to raise exception on error status
+            webhook_url: Optional URL to receive a POST when the job reaches a terminal state.
+                         Bria will sign the request with HMAC-SHA256; use
+                         ``verify_webhook_signature`` from ``bria_client`` to verify on receipt.
             **kwargs: Additional arguments (e.g., api_token)
 
         Returns:
             BriaResponse: The API response with request_id for polling
         """
         self._validate_submit_payload(payload)
-        # Unpack payload and headers to avoid mutating the original input
-        bria_response = await self.engine.post_async(endpoint=endpoint, payload={**payload, "sync": False}, headers={**(headers or {})}, **kwargs)
+        merged_payload = {**payload, "sync": False}
+        if webhook_url is not None:
+            merged_payload["webhook_url"] = webhook_url
+        bria_response = await self.engine.post_async(endpoint=endpoint, payload=merged_payload, headers={**(headers or {})}, **kwargs)
         if raise_for_status:
             bria_response.raise_for_status()
         return bria_response

--- a/src/bria_client/clients/async_client.py
+++ b/src/bria_client/clients/async_client.py
@@ -71,9 +71,7 @@ class BriaAsyncClient(BaseBriaClient):
             BriaResponse: The API response with request_id for polling
         """
         self._validate_submit_payload(payload)
-        merged_payload = {**payload, "sync": False}
-        if webhook_url is not None:
-            merged_payload["webhook_url"] = webhook_url
+        merged_payload = {**payload, "sync": False, "webhook_url": webhook_url}
         bria_response = await self.engine.post_async(endpoint=endpoint, payload=merged_payload, headers={**(headers or {})}, **kwargs)
         if raise_for_status:
             bria_response.raise_for_status()

--- a/src/bria_client/clients/async_client.py
+++ b/src/bria_client/clients/async_client.py
@@ -64,7 +64,7 @@ class BriaAsyncClient(BaseBriaClient):
             raise_for_status: Whether to raise exception on error status
             webhook_url: Optional URL to receive a POST when the job reaches a terminal state.
                          Bria will sign the request with HMAC-SHA256; use
-                         ``verify_webhook_signature`` from ``bria_client`` to verify on receipt.
+                         ``verify_webhook_signature`` from ``bria_client.toolkit`` to verify on receipt.
             **kwargs: Additional arguments (e.g., api_token)
 
         Returns:

--- a/src/bria_client/clients/sync_client.py
+++ b/src/bria_client/clients/sync_client.py
@@ -69,7 +69,9 @@ class BriaSyncClient(BaseBriaClient):
             BriaResponse: The API response with request_id for polling
         """
         self._validate_submit_payload(payload)
-        merged_payload = {**payload, "sync": False, "webhook_url": webhook_url}
+        merged_payload = {**payload, "sync": False}
+        if webhook_url is not None:
+            merged_payload["webhook_url"] = webhook_url
         bria_response = self.engine.post(endpoint=endpoint, payload=merged_payload, headers={**(headers or {})}, **kwargs)
         if raise_for_status:
             bria_response.raise_for_status()

--- a/src/bria_client/clients/sync_client.py
+++ b/src/bria_client/clients/sync_client.py
@@ -62,7 +62,7 @@ class BriaSyncClient(BaseBriaClient):
             raise_for_status: Whether to raise exception on error status
             webhook_url: Optional URL to receive a POST when the job reaches a terminal state.
                          Bria will sign the request with HMAC-SHA256; use
-                         ``verify_webhook_signature`` from ``bria_client`` to verify on receipt.
+                         ``verify_webhook_signature`` from ``bria_client.toolkit`` to verify on receipt.
             **kwargs: Additional arguments (e.g., api_token)
 
         Returns:

--- a/src/bria_client/clients/sync_client.py
+++ b/src/bria_client/clients/sync_client.py
@@ -51,7 +51,7 @@ class BriaSyncClient(BaseBriaClient):
             bria_response.raise_for_status()
         return bria_response
 
-    def submit(self, endpoint: str, payload: dict, headers: dict | None = None, raise_for_status: bool = False, **kwargs):
+    def submit(self, endpoint: str, payload: dict, headers: dict | None = None, raise_for_status: bool = False, webhook_url: str | None = None, **kwargs):
         """
         Submit an asynchronous request (sync=False)
 
@@ -60,14 +60,17 @@ class BriaSyncClient(BaseBriaClient):
             payload: Request payload
             headers: Optional headers
             raise_for_status: Whether to raise exception on error status
+            webhook_url: Optional URL to receive a POST when the job reaches a terminal state.
+                         Bria will sign the request with HMAC-SHA256; use
+                         ``verify_webhook_signature`` from ``bria_client`` to verify on receipt.
             **kwargs: Additional arguments (e.g., api_token)
 
         Returns:
             BriaResponse: The API response with request_id for polling
         """
         self._validate_submit_payload(payload)
-        # Unpack payload and headers to avoid mutating the original input
-        bria_response = self.engine.post(endpoint=endpoint, payload={**payload, "sync": False}, headers={**(headers or {})}, **kwargs)
+        merged_payload = {**payload, "sync": False, "webhook_url": webhook_url}
+        bria_response = self.engine.post(endpoint=endpoint, payload=merged_payload, headers={**(headers or {})}, **kwargs)
         if raise_for_status:
             bria_response.raise_for_status()
         return bria_response

--- a/src/bria_client/toolkit/__init__.py
+++ b/src/bria_client/toolkit/__init__.py
@@ -2,5 +2,6 @@ from bria_client.toolkit.errors import BriaException
 from bria_client.toolkit.image import Image
 from bria_client.toolkit.models import BriaError, BriaResult, Status
 from bria_client.toolkit.response import BriaResponse
+from bria_client.toolkit.webhook_verification import verify_webhook_signature
 
-__all__ = ["Image", "BriaResponse", "Status", "BriaResult", "BriaError", "BriaException"]
+__all__ = ["Image", "BriaResponse", "Status", "BriaResult", "BriaError", "BriaException", "verify_webhook_signature"]

--- a/src/bria_client/toolkit/webhook_verification.py
+++ b/src/bria_client/toolkit/webhook_verification.py
@@ -34,9 +34,7 @@ def verify_webhook_signature(
     """
     signing_key = _derive_signing_key(api_token)
     message = f"{webhook_id}.{timestamp}.{payload.decode()}".encode()
-    expected = base64.b64encode(
-        hmac.new(signing_key, message, hashlib.sha256).digest()
-    ).decode()
+    expected = base64.b64encode(hmac.new(signing_key, message, hashlib.sha256).digest()).decode()
 
     for token in signature_header.split(","):
         token = token.strip()

--- a/src/bria_client/toolkit/webhook_verification.py
+++ b/src/bria_client/toolkit/webhook_verification.py
@@ -5,14 +5,6 @@ import hmac
 WEBHOOK_SIGNING_SALT = b"bria-webhook-signing-v1"
 
 
-def _derive_signing_key(api_token: str) -> bytes:
-    return hmac.new(
-        api_token.encode(),
-        WEBHOOK_SIGNING_SALT,
-        hashlib.sha256,
-    ).digest()
-
-
 def verify_webhook_signature(
     payload: bytes,
     webhook_id: str,
@@ -45,3 +37,11 @@ def verify_webhook_signature(
             if hmac.compare_digest(candidate, expected):
                 return True
     return False
+
+
+def _derive_signing_key(api_token: str) -> bytes:
+    return hmac.new(
+        api_token.encode(),
+        WEBHOOK_SIGNING_SALT,
+        hashlib.sha256,
+    ).digest()

--- a/src/bria_client/toolkit/webhook_verification.py
+++ b/src/bria_client/toolkit/webhook_verification.py
@@ -1,0 +1,47 @@
+import base64
+import hashlib
+import hmac
+
+
+def _derive_signing_key(api_token: str) -> bytes:
+    return hmac.new(
+        api_token.encode(),
+        b"bria-webhook-signing-v1",
+        hashlib.sha256,
+    ).digest()
+
+
+def verify_webhook_signature(
+    payload: bytes,
+    webhook_id: str,
+    timestamp: str,
+    signature_header: str,
+    api_token: str,
+) -> bool:
+    """
+    Verify an inbound Bria webhook using HMAC-SHA256.
+
+    Args:
+        payload:          Raw request body bytes.
+        webhook_id:       Value of the ``Bria-Webhook-Id`` header (the job's request_id).
+        timestamp:        Value of the ``Bria-Webhook-Timestamp`` header (Unix epoch string).
+        signature_header: Value of the ``Bria-Webhook-Signature`` header
+                          (comma-separated ``v1=<base64>`` tokens).
+        api_token:        Your Bria API token — used to derive the signing key.
+
+    Returns:
+        ``True`` if at least one token in the signature header is valid, ``False`` otherwise.
+    """
+    signing_key = _derive_signing_key(api_token)
+    message = f"{webhook_id}.{timestamp}.{payload.decode()}".encode()
+    expected = base64.b64encode(
+        hmac.new(signing_key, message, hashlib.sha256).digest()
+    ).decode()
+
+    for token in signature_header.split(","):
+        token = token.strip()
+        if token.startswith("v1="):
+            candidate = token[3:]
+            if hmac.compare_digest(candidate, expected):
+                return True
+    return False

--- a/src/bria_client/toolkit/webhook_verification.py
+++ b/src/bria_client/toolkit/webhook_verification.py
@@ -2,11 +2,13 @@ import base64
 import hashlib
 import hmac
 
+WEBHOOK_SIGNING_SALT = b"bria-webhook-signing-v1"
+
 
 def _derive_signing_key(api_token: str) -> bytes:
     return hmac.new(
         api_token.encode(),
-        b"bria-webhook-signing-v1",
+        WEBHOOK_SIGNING_SALT,
         hashlib.sha256,
     ).digest()
 

--- a/tests/component/test_client.py
+++ b/tests/component/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 
+from bria_client.clients.async_client import BriaAsyncClient
 from bria_client.clients.sync_client import BriaSyncClient
 from bria_client.toolkit import BriaResponse
 from bria_client.toolkit.models import BriaResult, Status
@@ -43,3 +44,60 @@ class TestClient:
         call_args = mock_post.call_args
         headers = call_args.kwargs["headers"]
         assert headers["api_token"] == test_api_token
+
+
+@pytest.mark.component
+class TestAsyncClientWebhook:
+    @pytest.mark.asyncio
+    async def test_submit_includes_webhook_url_in_payload(self, mocker):
+        # Arrange
+        client = BriaAsyncClient(base_url="https://test.example.com", api_token="default_token")
+        mock_response = BriaResponse(status=Status.RUNNING, request_id="test_789", result=None)
+        mock_post = mocker.patch.object(client.engine.client, "request", return_value=mock_response)
+
+        # Act
+        await client.submit(
+            endpoint="/test/endpoint",
+            payload={"test": "data"},
+            webhook_url="https://my-server.example.com/webhook",
+        )
+
+        # Assert
+        mock_post.assert_called_once()
+        payload_sent = mock_post.call_args.kwargs["payload"]
+        assert payload_sent["webhook_url"] == "https://my-server.example.com/webhook"
+        assert payload_sent["sync"] is False
+
+    @pytest.mark.asyncio
+    async def test_submit_without_webhook_url_omits_field(self, mocker):
+        # Arrange
+        client = BriaAsyncClient(base_url="https://test.example.com", api_token="default_token")
+        mock_response = BriaResponse(status=Status.RUNNING, request_id="test_000", result=None)
+        mock_post = mocker.patch.object(client.engine.client, "request", return_value=mock_response)
+
+        # Act
+        await client.submit(endpoint="/test/endpoint", payload={"test": "data"})
+
+        # Assert
+        mock_post.assert_called_once()
+        payload_sent = mock_post.call_args.kwargs["payload"]
+        assert "webhook_url" not in payload_sent
+
+    @pytest.mark.asyncio
+    async def test_submit_does_not_mutate_original_payload(self, mocker):
+        # Arrange
+        client = BriaAsyncClient(base_url="https://test.example.com", api_token="default_token")
+        mock_response = BriaResponse(status=Status.RUNNING, request_id="test_111", result=None)
+        mocker.patch.object(client.engine.client, "request", return_value=mock_response)
+        original_payload = {"test": "data"}
+
+        # Act
+        await client.submit(
+            endpoint="/test/endpoint",
+            payload=original_payload,
+            webhook_url="https://my-server.example.com/webhook",
+        )
+
+        # Assert
+        assert "webhook_url" not in original_payload
+        assert "sync" not in original_payload

--- a/tests/component/test_client.py
+++ b/tests/component/test_client.py
@@ -84,6 +84,21 @@ class TestAsyncClientWebhook:
         assert "webhook_url" not in payload_sent
 
     @pytest.mark.asyncio
+    async def test_submit_preserves_webhook_url_from_payload(self, mocker):
+        client = BriaAsyncClient(base_url="https://test.example.com", api_token="default_token")
+        mock_response = BriaResponse(status=Status.RUNNING, request_id="test_222", result=None)
+        mock_post = mocker.patch.object(client.engine.client, "request", return_value=mock_response)
+
+        await client.submit(
+            endpoint="/test/endpoint",
+            payload={"test": "data", "webhook_url": "https://my-server.example.com/webhook"},
+        )
+
+        mock_post.assert_called_once()
+        payload_sent = mock_post.call_args.kwargs["payload"]
+        assert payload_sent["webhook_url"] == "https://my-server.example.com/webhook"
+
+    @pytest.mark.asyncio
     async def test_submit_does_not_mutate_original_payload(self, mocker):
         # Arrange
         client = BriaAsyncClient(base_url="https://test.example.com", api_token="default_token")

--- a/tests/unit/toolkit/test_webhook_verification.py
+++ b/tests/unit/toolkit/test_webhook_verification.py
@@ -1,0 +1,60 @@
+import base64
+import hashlib
+import hmac
+
+import pytest
+
+from bria_client.toolkit.webhook_verification import verify_webhook_signature
+
+API_TOKEN = "test-api-token"
+WEBHOOK_ID = "req_abc123"
+TIMESTAMP = "1700000000"
+PAYLOAD = b'{"status":"COMPLETED","request_id":"req_abc123"}'
+
+
+def _make_signature(api_token: str, webhook_id: str, timestamp: str, payload: bytes) -> str:
+    signing_key = hmac.new(api_token.encode(), b"bria-webhook-signing-v1", hashlib.sha256).digest()
+    message = f"{webhook_id}.{timestamp}.{payload.decode()}".encode()
+    sig = base64.b64encode(hmac.new(signing_key, message, hashlib.sha256).digest()).decode()
+    return f"v1={sig}"
+
+
+@pytest.mark.unit
+class TestVerifyWebhookSignature:
+    def test_valid_signature_returns_true(self):
+        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
+
+    def test_tampered_payload_returns_false(self):
+        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        tampered = b'{"status":"FAILED","request_id":"req_abc123"}'
+        assert verify_webhook_signature(tampered, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is False
+
+    def test_wrong_api_token_returns_false(self):
+        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, "wrong-token") is False
+
+    def test_tampered_webhook_id_returns_false(self):
+        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        assert verify_webhook_signature(PAYLOAD, "req_other", TIMESTAMP, header, API_TOKEN) is False
+
+    def test_tampered_timestamp_returns_false(self):
+        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, "9999999999", header, API_TOKEN) is False
+
+    def test_multiple_tokens_one_valid_returns_true(self):
+        valid = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        header = f"v1=invalidsig,{valid}"
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
+
+    def test_multiple_tokens_all_invalid_returns_false(self):
+        header = "v1=invalidsig1, v1=invalidsig2"
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is False
+
+    def test_token_with_whitespace_is_handled(self):
+        valid = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
+        header = f"  {valid}  "
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
+
+    def test_empty_signature_header_returns_false(self):
+        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, "", API_TOKEN) is False

--- a/tests/unit/toolkit/test_webhook_verification.py
+++ b/tests/unit/toolkit/test_webhook_verification.py
@@ -4,7 +4,7 @@ import hmac
 
 import pytest
 
-from bria_client.toolkit.webhook_verification import verify_webhook_signature
+from bria_client.toolkit.webhook_verification import verify_webhook_signature, WEBHOOK_SIGNING_SALT
 
 API_TOKEN = "test-api-token"
 WEBHOOK_ID = "req_abc123"
@@ -13,7 +13,7 @@ PAYLOAD = b'{"status":"COMPLETED","request_id":"req_abc123"}'
 
 
 def _make_signature(api_token: str, webhook_id: str, timestamp: str, payload: bytes) -> str:
-    signing_key = hmac.new(api_token.encode(), b"bria-webhook-signing-v1", hashlib.sha256).digest()
+    signing_key = hmac.new(api_token.encode(), WEBHOOK_SIGNING_SALT, hashlib.sha256).digest()
     message = f"{webhook_id}.{timestamp}.{payload.decode()}".encode()
     sig = base64.b64encode(hmac.new(signing_key, message, hashlib.sha256).digest()).decode()
     return f"v1={sig}"

--- a/tests/unit/toolkit/test_webhook_verification.py
+++ b/tests/unit/toolkit/test_webhook_verification.py
@@ -4,7 +4,7 @@ import hmac
 
 import pytest
 
-from bria_client.toolkit.webhook_verification import verify_webhook_signature, WEBHOOK_SIGNING_SALT
+from bria_client.toolkit.webhook_verification import WEBHOOK_SIGNING_SALT, verify_webhook_signature
 
 API_TOKEN = "test-api-token"
 WEBHOOK_ID = "req_abc123"

--- a/tests/unit/toolkit/test_webhook_verification.py
+++ b/tests/unit/toolkit/test_webhook_verification.py
@@ -25,35 +25,22 @@ class TestVerifyWebhookSignature:
         header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
         assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
 
-    def test_tampered_payload_returns_false(self):
+    @pytest.mark.parametrize(
+        "payload,webhook_id,timestamp,api_token",
+        [
+            (b'{"status":"FAILED"}', WEBHOOK_ID, TIMESTAMP, API_TOKEN),
+            (PAYLOAD, "req_other", TIMESTAMP, API_TOKEN),
+            (PAYLOAD, WEBHOOK_ID, "9999999999", API_TOKEN),
+            (PAYLOAD, WEBHOOK_ID, TIMESTAMP, "wrong-token"),
+        ],
+    )
+    def test_invalid_input_returns_false(self, payload, webhook_id, timestamp, api_token):
         header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
-        tampered = b'{"status":"FAILED","request_id":"req_abc123"}'
-        assert verify_webhook_signature(tampered, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is False
+        assert verify_webhook_signature(payload, webhook_id, timestamp, header, api_token) is False
 
-    def test_wrong_api_token_returns_false(self):
-        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
-        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, "wrong-token") is False
-
-    def test_tampered_webhook_id_returns_false(self):
-        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
-        assert verify_webhook_signature(PAYLOAD, "req_other", TIMESTAMP, header, API_TOKEN) is False
-
-    def test_tampered_timestamp_returns_false(self):
-        header = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
-        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, "9999999999", header, API_TOKEN) is False
-
-    def test_multiple_tokens_one_valid_returns_true(self):
+    def test_multiple_signatures_one_valid_returns_true(self):
         valid = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
         header = f"v1=invalidsig,{valid}"
-        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
-
-    def test_multiple_tokens_all_invalid_returns_false(self):
-        header = "v1=invalidsig1, v1=invalidsig2"
-        assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is False
-
-    def test_token_with_whitespace_is_handled(self):
-        valid = _make_signature(API_TOKEN, WEBHOOK_ID, TIMESTAMP, PAYLOAD)
-        header = f"  {valid}  "
         assert verify_webhook_signature(PAYLOAD, WEBHOOK_ID, TIMESTAMP, header, API_TOKEN) is True
 
     def test_empty_signature_header_returns_false(self):

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +63,13 @@ dependencies = [
     { name = "werkzeug" },
 ]
 
+[package.optional-dependencies]
+examples = [
+    { name = "fastapi" },
+    { name = "pyngrok" },
+    { name = "uvicorn" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
@@ -68,16 +84,20 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", marker = "extra == 'examples'", specifier = ">=0.136.1" },
     { name = "httpx", specifier = ">=0.24,<1.0" },
     { name = "httpx-retries", specifier = ">=0.1,<1.0" },
     { name = "numpy", specifier = ">=1.24,<3.0" },
     { name = "pillow", specifier = ">=9.0,<12.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.0,<3.0" },
+    { name = "pyngrok", marker = "extra == 'examples'", specifier = ">=8.1.2" },
     { name = "requests" },
     { name = "strenum", marker = "python_full_version < '3.11'" },
+    { name = "uvicorn", marker = "extra == 'examples'", specifier = ">=0.47.0" },
     { name = "werkzeug", specifier = ">=2.0,<4.0" },
 ]
+provides-extras = ["examples"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -199,6 +219,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -226,6 +258,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -856,6 +904,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyngrok"
+version = "8.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/ae/6664934258773db4666e65730c43b4b06730f78d49861a9a04ebcf4742ff/pyngrok-8.1.2.tar.gz", hash = "sha256:3b5383ec7dc4646ac0d046435eb58c6cd1cbc9acad70e6dee012b05dc25b070a", size = 45078, upload-time = "2026-04-29T15:16:53.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/5c/7733776a6a9704bffee19d203f9be80f25f78a5011a9863971be60fe2763/pyngrok-8.1.2-py3-none-any.whl", hash = "sha256:849e9f55706288b00eb28f4ae8ea16b05e52c609f80ef4a88ca23b385f2f9178", size = 25935, upload-time = "2026-04-29T15:16:52.088Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.407"
 source = { registry = "https://pypi.org/simple" }
@@ -1027,6 +1087,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
 name = "strenum"
 version = "0.4.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1112,6 +1185,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -73,7 +73,7 @@ examples = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
-    { name = "pyright" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "ruff" },
 ]
 test = [
@@ -102,7 +102,7 @@ provides-extras = ["examples"]
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
-    { name = "pyright", specifier = ">=1.1.407" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.407" },
     { name = "ruff", specifier = ">=0.14.0" },
 ]
 test = [
@@ -453,6 +453,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/70/a1e4f4d5986768ab90cc860b1cc3660fd2ded74ca175a900a5c29f839c7d/nodejs_wheel_binaries-24.15.0.tar.gz", hash = "sha256:b43f5c4f6e5768d8845b2ae4682eb703a19bf7aadc84187e2d903ed3a611c859", size = 8057, upload-time = "2026-04-19T15:48:16.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/66/54051d14853d6ab4fb85f8be9b042b530be653357fb9a19557498bc91ab7/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:a6232fa8b754220941f52388c8ead923f7c1c7fdf0ea0d98f657523bd9a81ef4", size = 55173485, upload-time = "2026-04-19T15:47:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5f/66acada164da5ca10a0824db021aa7394ae18396c550cd9280e839a43126/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:001a6b62c69d9109c1738163cca00608dd2722e8663af59300054ea02610972d", size = 55348100, upload-time = "2026-04-19T15:47:40.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/0cbd5ff40c9bb030ca1735d8f8793bd74f08a4cbd49100a1d19313ea57ab/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0fbc48765e60ed0ff30d43898dbf5cadbadf2e5f1e7f204afc2b01493b7ebce6", size = 59668206, upload-time = "2026-04-19T15:47:46.848Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d5/91ac63951ec75927a486b83b8cafe650e360fa70ac01dc94adfb32b93b97/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:20ee0536809795da8a4942fc1ab4cbdebbcaaf29383eab67ba8874268fb00008", size = 60206736, upload-time = "2026-04-19T15:47:52.668Z" },
+    { url = "https://files.pythonhosted.org/packages/db/72/dc22776974d928869c0c30d23ee98ed7df254243c2df68f09f5963e8e8b8/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1fade6c214285e72472ca40a631e98ff36559671cd5eefc8bf009471d67f04b4", size = 61720456, upload-time = "2026-04-19T15:47:58.325Z" },
+    { url = "https://files.pythonhosted.org/packages/01/0a/34461b9050cb45ee371dccdefc622aef6351506ea2691b08fc761ca67150/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3984cb8d87766567aee67a49743227ab40ede6f47734ec990ff90e50b74e7740", size = 62326172, upload-time = "2026-04-19T15:48:04.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/09252bf35672dba926649d59dfe51443a0f6955ad13784e91131d5ec82a2/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_amd64.whl", hash = "sha256:a437601956b532dcb3082046e6978e622733f90edc0932cbb9adb3bb97a16501", size = 41543461, upload-time = "2026-04-19T15:48:09.332Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/b649777d148e1e0c2ce349156603cdb12f7ed99921b95d93717393650193/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_arm64.whl", hash = "sha256:bdf4a431e08321a32efc604111c6f23941f87055d796a537e8c4110daecad23f", size = 39233248, upload-time = "2026-04-19T15:48:13.326Z" },
 ]
 
 [[package]]
@@ -926,6 +942,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
+]
+
+[package.optional-dependencies]
+nodejs = [
+    { name = "nodejs-wheel-binaries" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add outbound webhook support
Allows customers to receive a signed HTTP callback when an async job reaches a terminal state, instead of polling the status endpoint.

Changes
src/bria_client/clients/async_client.py

Added webhook_url: str | None = None parameter to BriaAsyncClient.submit(). When provided, the URL is merged into the request payload and sent to the API, which stores it and triggers delivery after the job completes or fails. The original payload dict is never mutated.

src/bria_client/toolkit/webhook_verification.py (new)

verify_webhook_signature(payload, webhook_id, timestamp, signature_header, api_token) — pure stdlib (no new dependencies) HMAC-SHA256 verifier for incoming Bria webhook deliveries.

The signing convention matches the server side exactly:

Signing key is derived as HMAC-SHA256(api_token, "bria-webhook-signing-v1") — the raw token is never stored anywhere
Signed message is {webhook_id}.{timestamp}.{body} (same as Svix/Stripe)
Signature header carries comma-separated v1=<base64> tokens; any one matching is accepted (supports key rotation)
Uses hmac.compare_digest to prevent timing attacks
src/bria_client/__init__.py

Exports verify_webhook_signature from the top-level package so customers can do from bria_client import verify_webhook_signature.

examples/webhook_handler.py (new)

Self-contained local-dev example with two parts:

Receiver — minimal FastAPI endpoint that reads the three Bria-Webhook-* headers, verifies the signature, returns 200 immediately, and defers processing to a background task (to stay within the 10s response window)
Sender — submits a job via BriaAsyncClient.submit(webhook_url=...) using asyncio.gather alongside uvicorn so both run concurrently; the submit coroutine sleeps 1s to let the server bind before firing
Optional pyngrok tunnel support for exposing localhost to a public HTTPS URL — falls back to WEBHOOK_URL env var, or raises RuntimeError immediately if neither is available.

tests/unit/toolkit/test_webhook_verification.py (new)

9 unit tests covering: valid signature, tampered payload/id/timestamp, wrong token, multiple v1= tokens (one valid, all invalid), whitespace handling, empty header.

tests/component/test_client.py

3 new component tests on BriaAsyncClient.submit(): webhook_url is forwarded in the payload, omitted when None, and the original payload dict is not mutated.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [X] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation only
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `ci`: CI/CD changes

## Checklist

- [X] I have run `ruff format` and `ruff check` locally
- [X] I have run `pyright` and fixed any type errors
- [X] I have added tests for my changes (if applicable)
- [X] All existing tests pass locally
- [ X] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #123" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new webhook capabilities and modifies the public `submit()` API for both sync and async clients, which can affect integrations and request payloads. Also introduces new HMAC verification logic and optional example dependencies that should be validated across environments.
> 
> **Overview**
> Adds outbound webhook support by allowing `BriaAsyncClient.submit()` and `BriaSyncClient.submit()` to accept an optional `webhook_url` and include it in the submitted payload without mutating the caller’s dict.
> 
> Introduces `toolkit.verify_webhook_signature` (HMAC-SHA256) for validating signed webhook deliveries, plus a new FastAPI-based `examples/webhook_handler.py` demonstrating end-to-end receipt/verification.
> 
> Updates CI and pre-commit to run Pyright separately on `src/`+`tests/` vs `examples/`, and adds an `[examples]` optional dependency group (FastAPI/uvicorn/pyngrok) along with updating `pyright` to `pyright[nodejs]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ad8657e5b3e3519f28960980d360cb48a23d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->