### PR TITLE
docs: add webhook and upload to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ A Python client library for the Bria Engine API, designed to make integrating po
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Usage Guide](#usage-guide)
+  - [Two Client Types](#two-client-types)
+  - [Three Request Methods](#three-request-methods)
+  - [Payload Handling](#payload-handling)
+  - [Webhooks](#webhooks)
+  - [Video Upload](#video-upload)
 - [Examples](#examples)
 - [Development Setup](#development-setup)
 - [Contributing](#contributing)
@@ -109,6 +114,63 @@ response = client.run(
     }
 )
 ```
+
+### Webhooks
+
+Instead of polling, you can ask Bria to POST the result to your server as soon as a job completes. Pass `webhook_url` to `.submit()`:
+
+```python
+response = client.submit(
+    endpoint="video/edit/remove_background",
+    payload={"video": file_url},
+    webhook_url="https://your-server.example.com/webhook",
+)
+print(f"Submitted: {response.request_id}")
+```
+
+Bria signs every delivery with HMAC-SHA256. Verify the signature before processing the payload:
+
+```python
+from bria_client.toolkit import verify_webhook_signature
+
+# In your webhook receiver (e.g. a FastAPI POST handler):
+body = await request.body()
+is_valid = verify_webhook_signature(
+    payload=body,
+    webhook_id=request.headers["bria-webhook-id"],
+    timestamp=request.headers["bria-webhook-timestamp"],
+    signature_header=request.headers["bria-webhook-signature"],
+    api_token=os.environ["BRIA_API_TOKEN"],
+)
+if not is_valid:
+    raise HTTPException(status_code=401, detail="Invalid webhook signature")
+```
+
+**Best practices:**
+- Respond with a 2xx status within **10 seconds** — defer any heavy processing to a background task.
+- Always verify the signature before acting on the payload.
+
+See [`examples/webhook_handler.py`](examples/webhook_handler.py) for a complete FastAPI receiver with optional ngrok tunnel for local development.
+
+### Video Upload
+
+Video endpoints expect a hosted URL. If you have a local file, use `client.upload()` to get one via a presigned upload:
+
+```python
+file_url = client.upload("path/to/video.mp4", media_type="video/mp4")
+
+response = client.submit(
+    endpoint="video/edit/remove_background",
+    payload={"video": file_url},
+)
+
+result = client.poll(response, timeout=300)
+print(result.result)
+```
+
+The returned `file_url` is valid for approximately 24 hours.
+
+See [`examples/video_upload.py`](examples/video_upload.py) for the full example.
 
 ## Examples
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [X] `docs`: Documentation only
- [ ] `refactor`: Code refactoring (no functional changes)
- [ ] `test`: Adding or updating tests
- [ ] `chore`: Maintenance tasks
- [ ] `ci`: CI/CD changes

## Checklist

- [ ] I have run `ruff format` and `ruff check` locally
- [ ] I have run `pyright` and fixed any type errors
- [ ] I have added tests for my changes (if applicable)
- [ ] All existing tests pass locally
- [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/) format

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #123" -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Expands **README** usage docs with two new **Usage Guide** sections and matching table-of-contents links.
> 
> **Webhooks** documents submitting jobs with `webhook_url`, verifying HMAC-SHA256 deliveries via `verify_webhook_signature`, response-time guidance, and points to `examples/webhook_handler.py`.
> 
> **Video upload** documents using `client.upload()` for presigned local video upload, wiring the returned URL into submit/poll flows, ~24h URL lifetime, and links to `examples/video_upload.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7930e7d7a93aa10c756b8b8e74857c0ea4d4c1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->